### PR TITLE
Finder now returns only matching classes for STI

### DIFF
--- a/lib/modis/attribute.rb
+++ b/lib/modis/attribute.rb
@@ -88,7 +88,6 @@ module Modis
     protected
 
     def set_sti_type
-      return unless self.class.sti_child?
       write_attribute(:type, self.class.name)
     end
 

--- a/lib/modis/finder.rb
+++ b/lib/modis/finder.rb
@@ -18,7 +18,7 @@ module Modis
           end
         end
 
-        records_to_models(records)
+        records_to_models(records).select { |model| model.class.ancestors.include?(self) }
       end
 
       def attributes_for(redis, id)

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -211,7 +211,7 @@ module Modis
 
       if new_record? || persist_all
         attributes.each do |k, v|
-          if (self.class.attributes[k][:default] || nil) != v
+          if (self.class.attributes[k].try(:'[]', :default) || nil) != v
             attrs << k << coerce_for_persistence(v)
           end
         end

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -62,6 +62,24 @@ describe Modis::Finder do
       model.destroy
       expect(FindersSpec::User.all).to eq([])
     end
+
+    describe 'does only return models from the same class' do
+      let!(:consumer) { FindersSpec::Consumer.create!(name: 'Franzl', age: 25) }
+      let!(:producer_1) { FindersSpec::Producer.create!(name: 'Tanya', age: 30) }
+      let!(:producer_2) { FindersSpec::Producer.create!(name: 'Kyle', age: 32) }
+
+      it 'finds all Users with the User finder (including STI children Consumer and Producer)' do
+        expect(FindersSpec::User.all).to eq([model, consumer, producer_1, producer_2])
+      end
+
+      it 'finds only Consumers with the Consumer finder (STI child of User)' do
+        expect(FindersSpec::Consumer.all).to eq([consumer])
+      end
+
+      it 'finds only Producers with the Producer finder (STI child of User)' do
+        expect(FindersSpec::Producer.all).to eq([producer_1, producer_2])
+      end
+    end
   end
 
   it 'identifies a found record as not being new' do


### PR DESCRIPTION
* Single Table Inheritance made finders return all models from that class tree
* Single Table Inheritance also made parent classes "obtain" the type of child classes when de-serialized

Fixes https://github.com/rpush/rpush/issues/147

@ileitch, please let me know what you think of the fix :smile: anything I should change before you want to merge?