### PR TITLE
New option for Modis::Model - :enable_all_index

### DIFF
--- a/lib/modis/finder.rb
+++ b/lib/modis/finder.rb
@@ -13,6 +13,11 @@ module Modis
       end
 
       def all
+        unless all_index_enabled?
+          raise IndexError, "Unable to retrieve all records of #{name}, "\
+            "because you disabled all index. See :enable_all_index for more."
+        end
+
         records = Modis.with_connection do |redis|
           ids = redis.smembers(key_for(:all))
           redis.pipelined do

--- a/spec/finder_spec.rb
+++ b/spec/finder_spec.rb
@@ -22,6 +22,10 @@ module FindersSpec
 
   class Worker < Producer
   end
+
+  class UserNoAllIndex < User
+    enable_all_index false
+  end
 end
 
 describe Modis::Finder do
@@ -66,6 +70,12 @@ describe Modis::Finder do
     it 'does not return a destroyed record' do
       model.destroy
       expect(FindersSpec::User.all).to eq([])
+    end
+
+    it 'throws error when enable_all_index option is set to false' do
+      FindersSpec::UserNoAllIndex.create!(name: 'Yana')
+      expect { FindersSpec::UserNoAllIndex.all }
+        .to raise_error(Modis::IndexError)
     end
   end
 

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -47,6 +47,10 @@ module PersistenceSpec
       called_callbacks << :test_before_save
     end
   end
+
+  class MockModelNoAllIndex < MockModel
+    enable_all_index false
+  end
 end
 
 describe Modis::Persistence do
@@ -294,6 +298,24 @@ describe Modis::Persistence do
 
     it 'returns false if the model is invalid' do
       expect(model.update_attributes(name: nil)).to be false
+    end
+  end
+
+  describe 'key for all records' do
+    let(:all_key_name) { "#{PersistenceSpec::MockModel.absolute_namespace}:all" }
+
+    describe 'when :enable_all_index option is set to false' do
+      it 'does not save new record to the *:all key' do
+        model = PersistenceSpec::MockModel.create!(name: 'Sage')
+        expect(Redis.new.smembers(all_key_name).map(&:to_i)).to include(model.id)
+      end
+    end
+
+    describe 'when :enable_all_index option is set to false' do
+      it 'does not save new record to the *:all key' do
+        model = PersistenceSpec::MockModelNoAllIndex.create!(name: 'Alex')
+        expect(Redis.new.smembers(all_key_name).map(&:to_i)).to_not include(model.id)
+      end
     end
   end
 end


### PR DESCRIPTION
Allows to disable creating of `my:core:key:all` kind of keys if they are not needed.
Getting rid of these keys is important feature, because those keys consume a huge amount of memory.

For example, one single `*:all` key having 158m ids consumes about of 10GB of RAM.
Assuming some people don't use Model.all in their code,
it's important to disable that feature on demand