### PR TITLE
Fix CI failures by resolving RuboCop offenses

### DIFF
--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -20,16 +20,19 @@ module Modis
   @mutex = Mutex.new
 
   class << self
+    attr_writer :redis_options, :connection_pool_size, :connection_pool_timeout,
+                :connection_pool
+
     def redis_options
-      { driver: :hiredis }
+      @redis_options ||= { driver: :hiredis }
     end
 
     def connection_pool_size
-      5
+      @connection_pool_size ||= 5
     end
 
     def connection_pool_timeout
-      5
+      @connection_pool_timeout ||= 5
     end
 
     def connection_pool

--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -20,23 +20,28 @@ module Modis
   @mutex = Mutex.new
 
   class << self
-    attr_accessor :connection_pool, :redis_options, :connection_pool_size,
-                  :connection_pool_timeout
-  end
-
-  self.redis_options = { driver: :hiredis }
-  self.connection_pool_size = 5
-  self.connection_pool_timeout = 5
-
-  def self.connection_pool
-    return @connection_pool if @connection_pool
-    @mutex.synchronize do
-      options = { size: connection_pool_size, timeout: connection_pool_timeout }
-      @connection_pool = ConnectionPool.new(options) { Redis.new(redis_options) }
+    def redis_options
+      { driver: :hiredis }
     end
-  end
 
-  def self.with_connection
-    connection_pool.with { |connection| yield(connection) }
+    def connection_pool_size
+      5
+    end
+
+    def connection_pool_timeout
+      5
+    end
+
+    def connection_pool
+      return @connection_pool if @connection_pool
+      @mutex.synchronize do
+        options = { size: connection_pool_size, timeout: connection_pool_timeout }
+        @connection_pool = ConnectionPool.new(options) { Redis.new(redis_options) }
+      end
+    end
+
+    def with_connection
+      connection_pool.with { |connection| yield(connection) }
+    end
   end
 end

--- a/lib/modis/attribute.rb
+++ b/lib/modis/attribute.rb
@@ -53,7 +53,7 @@ module Modis
         end
         RUBY
 
-        class_eval <<-RUBY, __FILE__, __LINE__
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{name}
             attributes['#{name}']
           end

--- a/lib/modis/persistence.rb
+++ b/lib/modis/persistence.rb
@@ -223,6 +223,7 @@ module Modis
 
       future
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
     def coerced_attributes
       attrs = []
@@ -234,8 +235,8 @@ module Modis
           end
         end
       else
-        changed_attributes.each do |k, _|
-          attrs << k << coerce_for_persistence(attributes[k])
+        changed_attributes.each_key do |key|
+          attrs << key << coerce_for_persistence(attributes[key])
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 unless ENV['TRAVIS']
   begin
     require './spec/support/simplecov_helper'
-    include SimpleCovHelper
+    include SimpleCovHelper # rubocop:disable Style/MixinUsage
     start_simple_cov('unit')
   rescue LoadError
     puts "Coverage disabled."


### PR DESCRIPTION
Resolves RuboCop failures present in travis build failure on master. These changes make rubocop complete successfully.  Before starting, these were the 5 reported offenses:


```
Offenses:

lib/modis.rb:31:3: W: Lint/DuplicateMethods: Method Modis.connection_pool is defined at both lib/modis.rb:23 and lib/modis.rb:31.
  def self.connection_pool
  ^^^
spec/spec_helper.rb:6:5: C: Style/MixinUsage: include is used at the top level. Use inside class or module.
    include SimpleCovHelper
    ^^^^^^^^^^^^^^^^^^^^^^^
lib/modis/persistence.rb:196:1: W: Lint/MissingCopEnableDirective: Re-enable Metrics/AbcSize cop with # rubocop:enable after disabling it.
    # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
^
lib/modis/persistence.rb:237:28: C: Performance/HashEachMethods: Use each_key instead of each.
        changed_attributes.each do |k, _|
                           ^^^^
lib/modis/attribute.rb:56:39: C: Style/EvalWithLocation: Use __LINE__ + 1 instead of __LINE__, as they are used by backtraces.
        class_eval <<-RUBY, __FILE__, __LINE__
```