### PR TITLE
Resolve rubocop violations and lock version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rspec'
 platform :mri do
   gem 'cane'
   gem 'codeclimate-test-reporter', require: nil
-  gem 'rubocop', require: false
+  gem 'rubocop', '0.61.1', require: false
   gem 'simplecov', require: false
 end
 

--- a/lib/modis.rb
+++ b/lib/modis.rb
@@ -37,6 +37,7 @@ module Modis
 
     def connection_pool
       return @connection_pool if @connection_pool
+
       @mutex.synchronize do
         options = { size: connection_pool_size, timeout: connection_pool_timeout }
         @connection_pool = ConnectionPool.new(options) { Redis.new(redis_options) }

--- a/lib/modis/attribute.rb
+++ b/lib/modis/attribute.rb
@@ -37,6 +37,7 @@ module Modis
 
         type_classes = Array(type).map do |t|
           raise UnsupportedAttributeType, t unless TYPES.key?(t)
+
           TYPES[t]
         end.flatten
 
@@ -91,6 +92,7 @@ module Modis
 
     def set_sti_type
       return unless self.class.sti_child?
+
       write_attribute(:type, self.class.name)
     end
 

--- a/lib/modis/finder.rb
+++ b/lib/modis/finder.rb
@@ -33,9 +33,7 @@ module Modis
 
         attributes = deserialize(record_for(redis, id))
 
-        unless attributes['id'].present?
-          raise RecordNotFound, "Couldn't find #{name} with id=#{id}"
-        end
+        raise RecordNotFound, "Couldn't find #{name} with id=#{id}" unless attributes['id'].present?
 
         attributes
       end
@@ -69,6 +67,7 @@ module Modis
       def model_for(attributes)
         cls = model_class(attributes)
         return unless cls == self || cls < self
+
         cls.new(attributes, new_record: false)
       end
 
@@ -79,6 +78,7 @@ module Modis
 
       def model_class(record)
         return self if record["type"].blank?
+
         record["type"].constantize
       end
     end

--- a/lib/modis/index.rb
+++ b/lib/modis/index.rb
@@ -21,14 +21,17 @@ module Modis
       def index(attribute)
         attribute = attribute.to_s
         raise IndexError, "No such attribute '#{attribute}'" unless attributes.key?(attribute)
+
         indexed_attributes << attribute
       end
 
       def where(query)
         raise IndexError, 'Queries using multiple indexes is not currently supported.' if query.keys.size > 1
+
         attribute, value = query.first
         ids = index_for(attribute, value)
         return [] if ids.empty?
+
         find_all(ids)
       end
 

--- a/lib/modis/model.rb
+++ b/lib/modis/model.rb
@@ -38,6 +38,7 @@ module Modis
       reset_changes
 
       return unless options.key?(:new_record)
+
       instance_variable_set('@new_record', options[:new_record])
     end
 

--- a/modis.gemspec
+++ b/modis.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'activemodel', '>= 3.0'
-  gem.add_runtime_dependency 'activesupport', '>= 3.0'
+  gem.add_runtime_dependency 'activemodel', ['>= 3.0', '< 5.2']
+  gem.add_runtime_dependency 'activesupport', ['>= 3.0', '< 5.2']
   gem.add_runtime_dependency 'redis', '>= 3.0'
   gem.add_runtime_dependency 'hiredis', '>= 0.5'
   gem.add_runtime_dependency 'connection_pool', '>= 2'

--- a/spec/support/simplecov_helper.rb
+++ b/spec/support/simplecov_helper.rb
@@ -14,9 +14,7 @@ module SimpleCovHelper
       if ENV['TRAVIS']
         require 'codeclimate-test-reporter'
 
-        if CodeClimate::TestReporter.run?
-          formatters << CodeClimate::TestReporter::Formatter
-        end
+        formatters << CodeClimate::TestReporter::Formatter if CodeClimate::TestReporter.run?
       end
 
       formatter SimpleCov::Formatter::MultiFormatter.new(*formatters)


### PR DESCRIPTION
1. Resolves rubocop offenses
2. Locks rubocop version
3. Limits `activemodel` and `activesupport` versions until compatibility is achieved