### PR TITLE
Lock i18n version

### DIFF
--- a/modis.gemspec
+++ b/modis.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.3.0"
 
-  gem.add_runtime_dependency 'activemodel', ['>= 4.2']
-  gem.add_runtime_dependency 'activesupport', ['>= 4.2']
+  gem.add_runtime_dependency 'activemodel', '>= 4.2'
+  gem.add_runtime_dependency 'activesupport', '>= 4.2'
+  gem.add_runtime_dependency 'i18n', ['>= 0.7', '< 1.3']
   gem.add_runtime_dependency 'redis', '>= 3.0'
   gem.add_runtime_dependency 'hiredis', '>= 0.5'
   gem.add_runtime_dependency 'connection_pool', '>= 2'


### PR DESCRIPTION
This gem just released version 1.3.0 a few hours ago, which broke jruby tests against Rails 5.0+. It appears to be a change related to this commit: https://github.com/svenfuchs/i18n/commit/949dc641d81773977e432626427aa0f8971a1073 . Regardless, activemodel works fine with any version above 0.7.

---

Example error with backtrace:

```
 9) validations save! raises an error if the model is invalid
     Failure/Error:
       expect do
         expect(model.save!).to be false
       end.to raise_error(Modis::RecordInvalid)
       expected Modis::RecordInvalid, got #<NoMethodError: undefined method `symbolize_key' for #<Hash:0x2e6f610d>> with backtrace:
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/core_ext/hash.rb:17:in `block in deep_symbolize_keys'
         # org/jruby/RubyHash.java:1419:in `each'
         # org/jruby/RubyEnumerable.java:1189:in `each_with_object'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/core_ext/hash.rb:15:in `deep_symbolize_keys'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/simple.rb:46:in `store_translations'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/base.rb:220:in `block in load_file'
         # org/jruby/RubyHash.java:1419:in `each'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/base.rb:220:in `load_file'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/base.rb:18:in `block in load_translations'
         # org/jruby/RubyArray.java:1792:in `each'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/base.rb:18:in `load_translations'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/simple.rb:77:in `init_translations'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/backend/simple.rb:52:in `available_locales'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/config.rb:45:in `available_locales'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n/config.rb:51:in `available_locales_set'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n.rb:305:in `locale_available?'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n.rb:311:in `enforce_available_locales!'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/i18n-1.3.0/lib/i18n.rb:179:in `translate'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/naming.rb:189:in `human'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/errors.rb:498:in `generate_message'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/errors.rb:528:in `normalize_message'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/errors.rb:331:in `add'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/validations/presence.rb:7:in `validate_each'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/validator.rb:151:in `block in validate'
         # org/jruby/RubyArray.java:1792:in `each'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/validator.rb:148:in `validate'
         # org/jruby/RubyKernel.java:1942:in `public_send'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:405:in `block in make_lambda'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:169:in `block in halting'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:547:in `block in default_terminator'
         # org/jruby/RubyKernel.java:1181:in `catch'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:546:in `block in default_terminator'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:170:in `block in halting'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:454:in `block in call'
         # org/jruby/RubyArray.java:1792:in `each'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:454:in `call'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activesupport-5.0.7.1/lib/active_support/callbacks.rb:750:in `_run_validate_callbacks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/validations.rb:408:in `run_validations!'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/activemodel-5.0.7.1/lib/active_model/validations.rb:338:in `valid?'
         # ./lib/modis/persistence.rb:193:in `validate'
         # ./lib/modis/persistence.rb:179:in `create_or_update'
         # ./lib/modis/persistence.rb:132:in `save!'
         # ./spec/validations_spec.rb:41:in `block in <main>'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/matchers/built_in/raise_error.rb:52:in `matches?'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:27:in `with_matcher'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/expectation_target.rb:65:in `to'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/expectation_target.rb:101:in `to'
         # ./spec/validations_spec.rb:40:in `block in <main>'
         # org/jruby/RubyBasicObject.java:2666:in `instance_exec'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:254:in `block in run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `block in run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:251:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:629:in `block in run_examples'
         # org/jruby/RubyArray.java:2577:in `map'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:625:in `run_examples'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:591:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `block in run'
         # org/jruby/RubyArray.java:2577:in `map'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
         # org/jruby/RubyArray.java:2577:in `map'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1989:in `with_suite_hooks'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:111:in `block in run_specs'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:74:in `report'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:110:in `run_specs'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:87:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in `run'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in `invoke'
         # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/exe/rspec:4:in `<main>'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-support-3.8.0/lib/rspec/support.rb:97:in `block in Support'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-support-3.8.0/lib/rspec/support.rb:106:in `notify_failure'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:40:in `handle_failure'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:27:in `with_matcher'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/handler.rb:48:in `handle_matcher'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-expectations-3.8.2/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/validations_spec.rb:40:in `block in <main>'
     # org/jruby/RubyBasicObject.java:2666:in `instance_exec'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:254:in `block in run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `block in with_around_and_singleton_context_hooks'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `block in with_around_example_hooks'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `block in run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/hooks.rb:464:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:500:in `with_around_and_singleton_context_hooks'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example.rb:251:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:629:in `block in run_examples'
     # org/jruby/RubyArray.java:2577:in `map'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:625:in `run_examples'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:591:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `block in run'
     # org/jruby/RubyArray.java:2577:in `map'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/example_group.rb:592:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # org/jruby/RubyArray.java:2577:in `map'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/configuration.rb:1989:in `with_suite_hooks'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:111:in `block in run_specs'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:74:in `report'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:110:in `run_specs'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:87:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in `run'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in `invoke'
     # ./gemfiles/vendor/bundle/jruby/2.5.0/gems/rspec-core-3.8.0/exe/rspec:4:in `<main>'
```